### PR TITLE
Docker run

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,5 +37,6 @@ dependencies:
         - libpysal
         - esda
         - mapclassify
+        - giddy
         - region
         - datashader

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-# Run `conda-env create -f pysalworkshop.yml`
+# Run `conda-env create -f environment.yml`
 name: pysalworkshop
 channels:
   - conda-forge
@@ -37,6 +37,5 @@ dependencies:
         - libpysal
         - esda
         - mapclassify
-        - giddy
         - region
         - datashader

--- a/install.md
+++ b/install.md
@@ -74,7 +74,7 @@ To get a Jupyter session started, you can follow these steps:
 1. Run on the same terminal as above the following command:
 
 ```
-docker run --rm -ti -p 8888:8888 -v ${PWD}:/home/jovyan/work sjsrey/pysalworkshop:v1
+docker run --rm -ti -p 8888:8888 -v ${pwd}:/home/jovyan/work sjsrey/pysalworkshop:v1
 ```
 
 This will start the docker container and you should see something like the


### PR DESCRIPTION
Current Docker run command complains about the Upper case
![image](https://user-images.githubusercontent.com/7359284/68617494-43501900-047c-11ea-8e7f-41dee483f9b6.png)
After changing `PWD` to `pwd`, the command line works.